### PR TITLE
Remove need for node to be visible

### DIFF
--- a/src/Our.Umbraco.FriendlySitemap/Controllers/SitemapController.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Controllers/SitemapController.cs
@@ -38,7 +38,6 @@ namespace Our.Umbraco.FriendlySitemap.Controllers
             var nodes = startNode
                 .DescendantsOrSelf()
                 .Where(x => x.HasTemplate() == true)
-                .Where(x => x.IsVisible() == true)
                 .Where(x => x.Value<bool>("sitemapExclude") == false);
 
             XNamespace xmlns = "http://www.sitemaps.org/schemas/sitemap/0.9";


### PR DESCRIPTION
Removed `.IsVisible()` check when collecting nodes. This isn't especially needed for this, and is not how a lot of developers use `umbracoNaviHide` (mostly to hide nodes in navigation). This means a node needs a template and can be excluded using the `sitemapExclude` boolean property on a node.